### PR TITLE
wrong item in input collection used

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ And you can write to the whole output collection simultaneously if you wish:
 
 Inputs are similar, except you're reading them instead of turning them on and off. To read a single input:
 
-    my_value = pibrella.input.e.read()
+    my_value = pibrella.input.a.read()
 
 Or to read all inputs into a dictionary:
 
     inputs = pibrella.input.read()
-    input_e = inputs['e']
+    input_a = inputs['a']
 
 
 The button


### PR DESCRIPTION
I don't have a Pibrella, but looking at the library I don't see allowance for outputs to be used as inputs, or 'e' defined as a valid input.

Also, the Input section in the Quick Reference part at the end of this document seems to be missing (although some classes are described earlier).