### PR TITLE
Update pibrella.py (Wrong boolean test in buzzer.melody for notes list as frequenies or note keys)

### DIFF
--- a/pibrella.py
+++ b/pibrella.py
@@ -498,7 +498,7 @@ class Buzzer(Output):
             note = notes[int(delta)-1]
             
             
-            if is_notation:
+            if not is_notation:
                 # this note and above would be OVER NINE THOUSAND Hz!
                 # Treat it as an explicit pitch instead
                 if note == 0:


### PR DESCRIPTION
Boolean test is wrong..
is_notation is True when first value of notes is "N", then next values should be a note key : ['A','A#','B','C','C#','D','D#','E','F','F#','G','G#']
pibrella.buzzer.buzz(note) require a numeric value as frequency
Notes key are played by pibrella.buzzer.note(note)